### PR TITLE
updated manifests

### DIFF
--- a/src/addons/send2ue/blender_manifest.toml
+++ b/src/addons/send2ue/blender_manifest.toml
@@ -1,11 +1,11 @@
 schema_version = "1.0.0"
 id = "send2ue"
 name = "Send to Unreal"
-tagline = "Sends an asset to the first open Unreal Editor instance on your machine"
+tagline = "Send assets directly to an open Unreal Editor on your machine"
 version = "2.4.6"
 type = "add-on"
 tags = [ "Pipeline" ]
-blender_version_min = "3.6.0"
+blender_version_min = "4.2.0"
 website = "https://poly-hammer.github.io/BlenderTools/send2ue"
 maintainer = "JoshQuake, jack-yao91"
 license = [ "SPDX:MIT" ]

--- a/src/addons/ue2rigify/blender_manifest.toml
+++ b/src/addons/ue2rigify/blender_manifest.toml
@@ -1,11 +1,11 @@
 schema_version = "1.0.0"
 id = "ue2rigify"
 name = "UE to Rigify"
-tagline = "Allows you to drive a given rig and its animations with a Rigify rig."
+tagline = "Allows you to drive a given rig and animations with a Rigify rig"
 version = "1.7.0"
 type = "add-on"
 tags = ["Pipeline"]
-blender_version_min = "3.6.0"
+blender_version_min = "4.2.0"
 website = "https://poly-hammer.github.io/BlenderTools/ue2rigify"
 maintainer = "JoshQuake, jack-yao91"
 license = [ "SPDX:MIT" ]


### PR DESCRIPTION
- Taglines shortened to within 64 character limit
- Blender min versions set to 4.2.0 (Inside manifests only)