### PR TITLE
Send2UE - UseObjectOrigin Proper Scaling Fix

### DIFF
--- a/src/addons/send2ue/core/io/fbx_b3.py
+++ b/src/addons/send2ue/core/io/fbx_b3.py
@@ -422,8 +422,9 @@ def export(**keywords):
                         if asset_object == current_object:
                             # clear rotation and scale only if spawning actor
                             # https://github.com/EpicGamesExt/BlenderTools/issues/610
-                            rot = (0, 0, 0)
-                            scale = (1.0, 1.0, 1.0)
+                            if bpy.context.scene.send2ue.extensions.instance_assets.place_in_active_level:
+                                rot = (0, 0, 0)
+                                scale = (1.0 * SCALE_FACTOR, 1.0 * SCALE_FACTOR, 1.0 * SCALE_FACTOR)
                 else:
                     loc = Vector((0, 0, 0))
 

--- a/src/addons/send2ue/core/io/fbx_b4.py
+++ b/src/addons/send2ue/core/io/fbx_b4.py
@@ -507,8 +507,9 @@ def export(**keywords):
                         if asset_object == current_object:
                             # clear rotation and scale only if spawning actor
                             # https://github.com/EpicGamesExt/BlenderTools/issues/610
-                            rot = (0, 0, 0)
-                            scale = (1.0, 1.0, 1.0)
+                            if bpy.context.scene.send2ue.extensions.instance_assets.place_in_active_level:
+                                rot = (0, 0, 0)
+                                scale = (1.0 * SCALE_FACTOR, 1.0 * SCALE_FACTOR, 1.0 * SCALE_FACTOR)
                 else:
                     loc = Vector((0, 0, 0))
 


### PR DESCRIPTION
Scale was only meant to be overwritten when using instance assets extension. Also reverts #50