### PR TITLE
Send2UE - Avoid bpy.data.objects iterations

### DIFF
--- a/src/addons/send2ue/core/export.py
+++ b/src/addons/send2ue/core/export.py
@@ -303,8 +303,7 @@ def export_hair(asset_id, properties):
     utilities.deselect_all_objects()
 
     # clear animation transformations prior to export so groom exports with no distortion
-    # TODO: we apparently need to avoid operating on all objects in bpy.data.objects
-    for scene_object in bpy.data.objects:
+    for scene_object in bpy.context.scene.objects:
         if scene_object.animation_data:
             if scene_object.animation_data.action:
                 scene_object.animation_data.action = None

--- a/src/addons/send2ue/core/utilities.py
+++ b/src/addons/send2ue/core/utilities.py
@@ -291,7 +291,7 @@ def get_current_context():
     :return dict: A dictionary of values that are the current context.
     """
     object_contexts = {}
-    for scene_object in bpy.data.objects:
+    for scene_object in bpy.context.scene.objects:
         active_action_name = ''
         if scene_object.animation_data and scene_object.animation_data.action:
             active_action_name = scene_object.animation_data.action.name
@@ -972,7 +972,7 @@ def escape_local_view():
     for area in bpy.context.screen.areas:
         if area.type == 'VIEW_3D':
             if area.spaces[0].local_view:
-                for scene_object in bpy.data.objects:
+                for scene_object in bpy.context.scene.objects:
                     scene_object.local_view_set(area.spaces[0], True)
 
 
@@ -1208,7 +1208,7 @@ def deselect_all_objects():
     """
     This function deselects all object in the scene.
     """
-    for scene_object in bpy.data.objects:
+    for scene_object in bpy.context.scene.objects:
         scene_object.select_set(False)
 
 


### PR DESCRIPTION
Iterating through bpy.data.objects is against Extensions policy. Replaced instances with bpy.context.scene.objects.

I feel like this can break in certain use cases? Testing needed.

Closes #58