### PR TITLE
Send2UE -  Fixed ue2rigify extension attribute error and incorrect strip usage

### DIFF
--- a/src/addons/send2ue/__init__.py
+++ b/src/addons/send2ue/__init__.py
@@ -3,10 +3,8 @@
 import bpy
 import os
 import importlib
-from .constants import ToolInfo
 from . import operators, properties, constants
 from .dependencies import remote_execution, unreal
-from .dependencies.unreal import UnrealRemoteCalls
 from .ui import header_menu, addon_preferences, file_browser, dialog
 from .core import formatting, validations, settings, utilities, export, ingest, extension, io
 

--- a/src/addons/send2ue/core/utilities.py
+++ b/src/addons/send2ue/core/utilities.py
@@ -670,7 +670,7 @@ def set_to_title(text):
     :param str text: The original text to convert to a title.
     :return str: The new title text.
     """
-    return ' '.join([word.capitalize() for word in text.lower().split('_')]).strip('.json')
+    return ' '.join([word.capitalize() for word in text.lower().split('_')]).removesuffix('.json')
 
 
 def set_pose(rig_object, pose_values):

--- a/src/addons/send2ue/resources/extensions/ue2rigify.py
+++ b/src/addons/send2ue/resources/extensions/ue2rigify.py
@@ -35,7 +35,7 @@ class Ue2RigifyExtension(ExtensionBase):
         :param bool hide_value: The hide value to set the source rig to.
         :return bool: The original hide value of the source rig.
         """
-        if self.use_ue2rigify:
+        if self.use_ue2rigify and hasattr(bpy.context.scene, 'ue2rigify'):
             ue2rigify_properties = bpy.context.scene.ue2rigify
             if ue2rigify_properties.source_rig:
                 self.original_hide_value = ue2rigify_properties.source_rig.hide_get()
@@ -45,7 +45,7 @@ class Ue2RigifyExtension(ExtensionBase):
         """
         Sets the use_ue2rigify property depending on whether to use code from the ue2rigify addon or not.
         """
-        if bpy.context.preferences.addons.find('ue2rigify'):
+        if bpy.context.preferences.addons.find('ue2rigify') and hasattr(bpy.context.scene, 'ue2rigify'):
             ue2rigify_properties = bpy.context.scene.ue2rigify
             if ue2rigify_properties.selected_mode == self.control_mode:
                 self.use_ue2rigify = True
@@ -78,7 +78,7 @@ class Ue2RigifyExtension(ExtensionBase):
         asset_path = asset_data.get('asset_path')
         file_path = asset_data.get('file_path')
         control_rig_object = bpy.data.objects.get(self.control_rig_name)
-        action_name = asset_data.get('_action_name').strip(self.action_prefix)
+        action_name = asset_data.get('_action_name').removeprefix(self.action_prefix)
 
         if self.use_ue2rigify and control_rig_object:
             if control_rig_object.animation_data:
@@ -95,7 +95,7 @@ class Ue2RigifyExtension(ExtensionBase):
                 'asset_path': f'{os.path.dirname(asset_path)}/{action_name}',
                 'file_path': os.path.join(
                     os.path.dirname(file_path),
-                    os.path.basename(file_path).strip(self.action_prefix)
+                    os.path.basename(file_path).removeprefix(self.action_prefix)
                 )
             })
 
@@ -105,7 +105,7 @@ class Ue2RigifyExtension(ExtensionBase):
         """
         asset_path = asset_data.get('asset_path')
         control_rig_object = bpy.data.objects.get(self.control_rig_name)
-        action_name = os.path.basename(asset_path).strip(self.action_prefix)
+        action_name = os.path.basename(asset_path).removeprefix(self.action_prefix)
 
         if self.use_ue2rigify and control_rig_object:
             # mute the action


### PR DESCRIPTION
Solves an error with the ue2rigify extension in Send2UE when detecting the UE to Rigify addon.

Also includes replacements of invalid strips with corresponding replacesuffix or replaceprefix.