### PR TITLE
Send2UE - Added validate_unreal_plugins Property

### DIFF
--- a/src/addons/send2ue/core/validations.py
+++ b/src/addons/send2ue/core/validations.py
@@ -288,7 +288,7 @@ class ValidationManager:
         """
         Checks whether the required unreal plugins are enabled.
         """
-        if self.properties.import_grooms and self.hair_objects:
+        if self.properties.validate_unreal_plugins and self.properties.import_grooms and self.hair_objects:
             # A dictionary of plugins where the key is the plugin name and value is the plugin label.
             groom_plugins = {
                 'HairStrands': 'Groom',

--- a/src/addons/send2ue/properties.py
+++ b/src/addons/send2ue/properties.py
@@ -504,6 +504,11 @@ def get_scene_property_class():
             default=True,
             description="This checks that a mesh with an armature modifier has vertex groups"
         )
+        validate_unreal_plugins: bpy.props.BoolProperty(
+            name="Check Unreal has required plugins",
+            default=True,
+            description="Disable only if you know Groom plugin is enabled but still get an error"
+        )
 
     return Send2UeSceneProperties
 

--- a/src/addons/send2ue/resources/setting_templates/default.json
+++ b/src/addons/send2ue/resources/setting_templates/default.json
@@ -316,5 +316,6 @@
   "validate_project_settings": true,
   "validate_scene_scale": true,
   "validate_textures": false,
-  "validate_time_units": "off"
+  "validate_time_units": "off",
+  "validate_unreal_plugins": true
 }

--- a/src/addons/send2ue/ui/dialog.py
+++ b/src/addons/send2ue/ui/dialog.py
@@ -278,6 +278,7 @@ class Send2UnrealDialog(bpy.types.Panel):
         self.draw_property(properties, layout, 'validate_project_settings')
         self.draw_property(properties, layout, 'validate_object_names')
         self.draw_property(properties, layout, 'validate_meshes_for_vertex_groups')
+        self.draw_property(properties, layout, 'validate_unreal_plugins')
 
     def draw_extensions(self, layout):
         """


### PR DESCRIPTION
Added property to toggle for cases where Groom plugin may not be found in the .uproject but enabled as a requirement for another plugin.