### PR TITLE
Documentation - Repaired missing/broken links and fixed mkdocs errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-Directions on how to contribute can be found [here](https://poly-hammer.github.io/BlenderTools/contributing/development.html).
+Directions on how to contribute can be found [here](https://poly-hammer.github.io/BlenderTools/contributing/development/).

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ new animation on unreal marketplace assets and more!
 ## Help Contribute
 Contributions are encouraged! Find out how you can contribute to this repo in one of the following ways:
 
-* [Help Develop](https://poly-hammer.github.io/BlenderTools/contributing/development.html)
-* [Help Document](https://poly-hammer.github.io/BlenderTools/contributing/documentation.html)
-* [Help Test](https://poly-hammer.github.io/BlenderTools/contributing/testing.html)
+* [Help Develop](https://poly-hammer.github.io/BlenderTools/contributing/development/)
+* [Help Document](https://poly-hammer.github.io/BlenderTools/contributing/documentation/)
+* [Help Test](https://poly-hammer.github.io/BlenderTools/contributing/testing/)
 
 
 ## Get Notified on a New Release

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -39,4 +39,4 @@ The can be built into a single static html site by running:
 mkdocs build
 ```
 
-They are built and deployed using this [workflow](https://github.com/poly-hammer/BlenderTools/.github/workflows/docs.yml)
+They are built and deployed using this [workflow](https://github.com/poly-hammer/BlenderTools/blob/main/.github/workflows/docs.yml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 A one-click solution for sending assets from Blender to Unreal Engine.
 
-* [Read Docs](./send2ue)
+* [Read Docs](send2ue/index.md)
 * [Download Addon](https://github.com/poly-hammer/BlenderTools/releases?q=Send+to+Unreal&expanded=true)
 
 
@@ -18,5 +18,5 @@ A node based retargeting system for Blender's
 [Rigify](https://docs.blender.org/manual/en/latest/addons/rigging/rigify/index.html) addon. Quickly retarget and author
 new animation on unreal marketplace assets and more!
 
-* [Read Docs](./ue2rigify)
+* [Read Docs](ue2rigify/index.md)
 * [Download Addon](https://github.com/poly-hammer/BlenderTools/releases?q=UE+to+Rigify&expanded=true)

--- a/docs/send2ue/asset-types/animation-sequence.md
+++ b/docs/send2ue/asset-types/animation-sequence.md
@@ -11,14 +11,14 @@ The NLA Editor is used to determine several things:
       Actions in blender all exist in the same data block namespace and just contain fcurves values.
       It is not until they are set in an object's animation data that a determination can be made that an action belongs to a particular object.
       This is different from how unreal AnimSequence assets work. Unreal AnimSequence assets must have an associated skeletal mesh in order to exist. Therefore,
-      Send to Unreal only exports skeletal mesh animation if the armature object has action strips in its NLA tracks. Also read about the [auto stash active action](https://poly-hammer.github.io/BlenderTools/send2ue/settings/export.html#auto-stash-active-action) option.
+      Send to Unreal only exports skeletal mesh animation if the armature object has action strips in its NLA tracks. Also read about the [auto stash active action](../settings/export.md#auto-stash-active-action) option.
 
 
 2. Which action to export, by checking which NLA tracks are not muted.
 !!! note 
 
       All un-muted strips in the NLA Editor will be sent as an AnimSequence of the skeleton
-      that is in the `Export` collection. Also read about the [Export All Actions](https://poly-hammer.github.io/BlenderTools/send2ue/settings/export.html#export-all-actions) option.
+      that is in the `Export` collection. Also read about the [Export All Actions](../settings/export.md#export-all-actions) option.
 
 3. The start and end of the Unreal Animation, by using the start and end frame of the clip.
 !!! note 
@@ -41,9 +41,9 @@ all sent in a single operation.
 ## Only Animation
 What if the skeleton and skeletal mesh already exist in your project, and you just want to
 import animation onto an existing skeleton? That can be done in two ways: (1) by turning off all
-import options in the [import settings](/settings/import.html) except for Animations;
+import options in the [import settings](../settings/import.md) except for Animations;
 (2) or by placing only the armature object in the `Export` collection. Both ways require you to set the project path
-to the Skeleton asset under the [Paths](https://poly-hammer.github.io/BlenderTools/send2ue/settings/paths.html#skeleton-asset-unreal)
+to the Skeleton asset under the [Paths](../settings/paths.md#skeleton-asset-unreal)
 tab in the settings dialog.
 
 ![4](./images/animation/4.gif)
@@ -57,7 +57,7 @@ tab in the settings dialog.
 In this case two strips were un-muted, therefore two animations were imported onto the referenced skeleton asset.
 !!! note 
       
-      Also if [export all actions](https://poly-hammer.github.io/BlenderTools/send2ue/settings/export.html#export-all-actions) was on, all actions would be exported regardless of their mute values.
+      Also if [export all actions](../settings/export.md#export-all-actions) was on, all actions would be exported regardless of their mute values.
 
 ## Morph Targets
 
@@ -65,7 +65,7 @@ Here is an example of how to send shape key animation in blender to unreal as an
 
 !!! note 
    
-      The [export custom property fcurves](https://poly-hammer.github.io/BlenderTools/send2ue/settings/export.html#export-custom-property-fcurves) must be set to true in
+      The [export custom property fcurves](../settings/export.md#export-custom-property-fcurves) must be set to true in
       order for this to work. Also note that this can apply to any custom property fcurves not just the morph targets fcurve.
 
 ![6](./images/animation/6.gif)

--- a/docs/send2ue/asset-types/groom.md
+++ b/docs/send2ue/asset-types/groom.md
@@ -19,7 +19,7 @@ imported to unreal as a groom asset.
 
 !!! tip
 
-    To gain more control over how particle systems are exported, use the [_combine assets_](https://poly-hammer.github.io/BlenderTools/send2ue/extensions/combine-assets.html)
+    To gain more control over how particle systems are exported, use the [_combine assets_](../extensions/combine-assets.md)
     extension that has options such as _combine groom for each mesh_ and more.
 
 
@@ -43,12 +43,12 @@ the curves object into a hair particle system on the mesh that it’s surfaced t
 
 By default, the groom asset will import along with the mesh asset that it is surfaced to. To run a strictly groom asset
 import (meaning no other asset types will be exported from blender and imported to unreal), all import options (mesh,
-animation, textures) must be turned off in your [import settings](https://poly-hammer.github.io/BlenderTools/send2ue/settings/import.html) except for `Groom`. Alternatively,
+animation, textures) must be turned off in your [import settings](../settings/import.md) except for `Groom`. Alternatively,
 the blender `Curves` objects can be placed in the `Export` collection (without their surface mesh objects) which
 denotes an exclusive groom workflow as well.
 
 ## Binding Assets and More
 
-The addon provides an extension called [create post import assets for groom](https://poly-hammer.github.io/BlenderTools/send2ue/extensions/create-post-import-groom-assets.html)
+The addon provides an extension called [create post import assets for groom](../extensions/create-post-import-groom-assets.md)
 to automatically create unreal assets (such as a binding asset) for the imported groom asset. See the extensions section
 for more information on its usage.

--- a/docs/send2ue/asset-types/skeletal-mesh.md
+++ b/docs/send2ue/asset-types/skeletal-mesh.md
@@ -24,7 +24,7 @@ as the skeleton and physics asset with `_Skeleton` and `_PhysicsAsset` post fixe
 
 
 To run a strictly skeletal mesh import(meaning no animation will be exported), the animations import option must be
-turned off in your [Import](/settings/import.html#animation) settings.
+turned off in your [Import](../settings/import.md#animation) settings.
 
 ![3](./images/skeletal-mesh/3.png)
 
@@ -60,4 +60,4 @@ Also notice that the LOD build settings can be set under the
 ## Only Mesh
 
 To run a strictly mesh asset import (ex: excluding import of particle systems as groom assets), all import options
-must be turned off in your [import settings](/settings/import.html) except for `Mesh`.
+must be turned off in your [import settings](../settings/import.md) except for `Mesh`.

--- a/docs/send2ue/asset-types/static-mesh.md
+++ b/docs/send2ue/asset-types/static-mesh.md
@@ -78,4 +78,4 @@ Any child mesh that has the pre fix `SOCKET_` in its name will be separately imp
 ## Only Mesh
 
 To run a strictly mesh asset import (ex: excluding import of particle systems as groom assets), all import options
-must be turned off in your [import settings](/settings/import.html) except for `Mesh`.
+must be turned off in your [import settings](../settings/import.md) except for `Mesh`.

--- a/docs/send2ue/customize/extensions.md
+++ b/docs/send2ue/customize/extensions.md
@@ -12,9 +12,9 @@
 
 Extensions provide a python interface for Send to Unreal users to quickly and cleanly extend its functionality
 with a minimal amount of code. Within an extension class several things can be defined:
-* [Tasks](/customize/extensions.html#tasks)
-* [Properties](/customize/extensions.html#properties)
-* [Draws](/customize/extensions.html#draws)
+* [Tasks](#tasks)
+* [Properties](#properties)
+* [Draws](#draws)
 
 ![1](./images/extensions/1.svg)
 
@@ -92,7 +92,7 @@ console and that the cube got sent to the `/Game/example_extension/test/` folder
 
 This same approach can be applied to many other use cases where you need to extend the Send to Unreal operation.
 For practical examples check out the
-[send2ue/resources](https://github.com/poly-hammer/BlenderTools/tree/master/send2ue/resources/extensions) folder.
+[send2ue/resources](https://github.com/poly-hammer/BlenderTools/tree/master/src/addons/send2ue/resources/extensions) folder.
 
 ## Tasks
 Tasks contain logic for key points within the runtime of the send to unreal

--- a/docs/send2ue/extensions/combine-assets.md
+++ b/docs/send2ue/extensions/combine-assets.md
@@ -58,7 +58,7 @@ will be combined into one skeletal mesh using the name of the first child mesh i
 !!! note
 
     This might not give you enough control over the skeletal mesh name, so using the
-    [immediate parent name](https://poly-hammer.github.io/BlenderTools/send2ue/extensions/use-immediate-parent-name.html)
+    [immediate parent name](use-immediate-parent-name.md)
     extension can be useful.
 
 ![2](./images/combine-assets/2.png)

--- a/docs/send2ue/extensions/create-post-import-groom-assets.md
+++ b/docs/send2ue/extensions/create-post-import-groom-assets.md
@@ -8,7 +8,7 @@ imported groom asset.
 ### Groom Binding Asset
 This creates a binding asset for the imported groom asset. The target skeletal mesh is the hair's surface mesh in blender
 that is part of the same import. For this option to work correctly, the _import mesh_ and _import groom_ options in the
-[import settings](https://poly-hammer.github.io/BlenderTools/send2ue/settings/import.html) must be turned on.
+[import settings](../settings/import.md) must be turned on.
 
 The binding asset will use the name of the groom asset and the name of the target skeletal mesh post fixed with `_Binding`.
 Note this is the unreal convention of naming binding assets.
@@ -18,7 +18,7 @@ will yield a binding asset named `hair_SK_Mannequin_Female_Binding`.
 
 !!! note
 
-    A binding asset can only be created when the groom's surface mesh is a [skeletal mesh](https://poly-hammer.github.io/BlenderTools/send2ue/asset-types/skeletal-mesh.html).
+    A binding asset can only be created when the groom's surface mesh is a [skeletal mesh](../asset-types/skeletal-mesh.md).
 
 ### Blueprint Asset with Groom
 This creates a blueprint asset for each imported skeletal mesh and its surface hairs. The blueprint asset will have
@@ -29,7 +29,7 @@ blueprint asset uses the name of the skeletal mesh asset with a postfix `_BP`.
     There are multiple hair systems surfaced on the mesh object `SK_Mannequin`, which results in a groom
     component created for each groom asset imported.
 
-  <img src="./images/create-post-import-groom-assets/2.png" alt="2" width="400"/>
+![2](./images/create-post-import-groom-assets/2.png){: style="width:400px"}
 
 !!! note
 

--- a/docs/send2ue/index.md
+++ b/docs/send2ue/index.md
@@ -1,7 +1,7 @@
 # Send to Unreal
 A one-click solution for sending data from Blender to Unreal Engine.
 
-[Quick Start](./introduction/quickstart.md)
+[Quick Start](introduction/quickstart.md)
   
 ## Features
 * ### Static Meshes
@@ -19,7 +19,7 @@ The reason our tool can provide a "one-click" solution for these assets is becau
 collection. That, along with giving the user the ability to customize and share settings templates, allows assets and scenes to be completely configured ahead of time.
 A saved file can be opened by an artist and in one-click they can have their assets in unreal engine. The main purpose of this tool
 is for rapid iteration and standardization of asset workflows. If you are interested in learning more, please read through the rest of our documentation
-starting with our [quickstart guide](./introduction/quickstart)
+starting with our [quickstart guide](introduction/quickstart.md)
 
 ## Help us document
 Our goal is for this documentation to be completely comprehensive so that it can be fully self-serving. If you notice any part of it to be incorrect, unclear, outdated, or missing

--- a/docs/send2ue/mkdocs.yml
+++ b/docs/send2ue/mkdocs.yml
@@ -1,6 +1,7 @@
-site_name: Send to Unreal
+site_name: send2ue
 docs_dir: '.'
 nav:
+  - Overview: "./index.md"
   - Quick Start: "./introduction/quickstart.md"
   - Asset Types:
     - Static Mesh: "./asset-types/static-mesh.md"

--- a/docs/send2ue/settings/import.md
+++ b/docs/send2ue/settings/import.md
@@ -25,7 +25,7 @@ When enabled this option launches the import UI in Unreal.
 
 ## LOD Settings
 The section contains the settings related to LOD workflows. You can read more about these under the
-[Skeletal Mesh](/asset-types/skeletal-mesh.html#lods) and [Static Mesh](/asset-types/static-mesh.html#lods) pages.
+[Skeletal Mesh](../asset-types/skeletal-mesh.md#lods) and [Static Mesh](../asset-types/static-mesh.md#lods) pages.
 
 #### LODs
 Whether or not to export the custom LODs

--- a/docs/ue2rigify/index.md
+++ b/docs/ue2rigify/index.md
@@ -2,7 +2,7 @@
 A node based retargeting system for Blender's Rigify addon.
 
 
-* [Quick Start](./introduction/quickstart)
+* [Quick Start](introduction/quickstart.md)
     
 ## Features
 * ### Retarget Animation

--- a/docs/ue2rigify/mkdocs.yml
+++ b/docs/ue2rigify/mkdocs.yml
@@ -1,6 +1,7 @@
-site_name: UE to Rigify
+site_name: ue2rigify
 docs_dir: '.'
 nav:
+  - Overview: "./index.md"
   - Quick Start: "./introduction/quickstart.md"
   - Concepts: 
     - Modes: "./concepts/modes.md"

--- a/docs/ue2rigify/mkdocs.yml
+++ b/docs/ue2rigify/mkdocs.yml
@@ -13,6 +13,10 @@ nav:
     - Relink Constraints: "./advanced/relink-constraints.md"
   - Extras: 
     - Community Templates: "./extras/community-templates.md"
+  - User Interface:
+    - 3D View Panel: "./user-interface/3d-view-panel.md"
+    - Node Editor Panel: "./user-interface/node-editor-panel.md"
+    - Hotkeys: "./user-interface/hot-keys.md"
   - Trouble Shooting: 
     - FAQ: "./trouble-shooting/faq.md"
     - Errors: "./trouble-shooting/errors.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Documentation
 
 nav:
+    - Home: index.md
     - Addons: 
         - Send to Unreal: '!include ./docs/send2ue/mkdocs.yml'
         - UE to Rigify: '!include ./docs/ue2rigify/mkdocs.yml'


### PR DESCRIPTION
## Overview
This is a pull aimed at fixing all remaining broken hyperlinks, images, and missing pages in the documentation. This is aimed at fixing the issue found here: #76.  It's not a lot of lines, but there's a good bit to go through!

## Changes
1. I have done so by updating the linking style to other pages to relative links to the markdown instead of absolute links to the `github.io` pages. This allows MKDocs to recognize and view the pages locally, and also allows more flexibility because the documentation can be uploaded anywhere, under any nested path. So, further changes to the naming won't require additional work updating the link addresses.

2. I also fixed one broken image in the process and updated it's link accordingly (found under `Send To Unreal > Supported Extensions > Create Post Import Groom Assets`).

3. I added missing pages to the navigation, including the index pages for the project, send2ue, and ue2rigify. Previously, once left, these pages could not be found again graphically. 

4. Additionally, I added 3 pages which were not added to the navigation related to `User Interface`. They appear to be complete and may be useful to some users, but if these are intentionally left out, I would be happy to revise this. They could also be placed under `not_in_nav:` in the configuration to keep them hidden but silence the warning. 

5. Lastly, in-order to unify the link structure, I set the `site_name` for the **send2ue** and **ue2rigify** to their corresponding folder names respectively, instead of `Send to Unreal` and `UE to Rigify`. Reason being: currently the index linked to for `Send to Unreal` is [https://poly-hammer.github.io/BlenderTools/send2ue](https://poly-hammer.github.io/BlenderTools/send2ue), however all endpoints nested under `/BlenderTools/send2ue` link instead to `/BlenderTools/send-to-unreal/<example>/`. These changes I have done will restore continuity, but if the path `send-to-unreal` is preferred, this can be fixed by renaming the folder rather than changing the `site_name` value. 

## Conclusion

Whew, that was a mouthful. This is my best take at updating the documentation, and in my testing, it fixes all the broken resources and leaves the MKDocs output squeaky-clean! However, I do know that numbers 4 and 5 especially may require modification or removal, so I am happy to make any of those changes upon request!