### PR TITLE
Custom root bone name setting

### DIFF
--- a/src/addons/send2ue/core/io/fbx_b3.py
+++ b/src/addons/send2ue/core/io/fbx_b3.py
@@ -348,7 +348,10 @@ def export(**keywords):
             obj_type = b"Camera"
 
         if ob_obj.type == 'ARMATURE':
-            if bpy.context.scene.send2ue.export_object_name_as_root:
+            if bpy.context.scene.send2ue.export_custom_root_name:
+                # if the user has provided a custom name for a root bone, use this directly
+                ob_obj.name = bpy.context.scene.send2ue.export_custom_root_name
+            elif bpy.context.scene.send2ue.export_object_name_as_root:
                 # if the object is already named armature this forces the object name to root
                 if 'armature' == ob_obj.name.lower():
                     ob_obj.name = 'root'

--- a/src/addons/send2ue/core/io/fbx_b4.py
+++ b/src/addons/send2ue/core/io/fbx_b4.py
@@ -434,7 +434,10 @@ def export(**keywords):
             obj_type = b"Camera"
 
         if ob_obj.type == 'ARMATURE':
-            if bpy.context.scene.send2ue.export_object_name_as_root:
+            if bpy.context.scene.send2ue.export_custom_root_name:
+                # if the user has provided a custom name for a root bone, use this directly
+                ob_obj.name = bpy.context.scene.send2ue.export_custom_root_name
+            elif bpy.context.scene.send2ue.export_object_name_as_root:
                 # if the object is already named armature this forces the object name to root
                 if 'armature' == ob_obj.name.lower():
                     ob_obj.name = 'root'

--- a/src/addons/send2ue/properties.py
+++ b/src/addons/send2ue/properties.py
@@ -286,6 +286,14 @@ def get_scene_property_class():
                 "the first bone in the armature hierarchy is used as the root bone in unreal."
             )
         )
+        export_custom_root_name: bpy.props.StringProperty(
+            name="Custom root bone name",
+            default="",
+            description=(
+                "If specified, this adds a root bone by this name in Unreal. This overrides the "
+                "\"Export object name as root bone\" setting."
+            )
+        )
         export_custom_property_fcurves: bpy.props.BoolProperty(
             name="Export custom property fcurves",
             default=True,

--- a/src/addons/send2ue/ui/dialog.py
+++ b/src/addons/send2ue/ui/dialog.py
@@ -63,6 +63,7 @@ class Send2UnrealDialog(bpy.types.Panel):
         properties = bpy.context.scene.send2ue
         self.draw_property(properties, layout, 'use_object_origin')
         self.draw_property(properties, layout, 'export_object_name_as_root')
+        self.draw_property(properties, layout, 'export_custom_root_name')
 
         #  animation settings box
         self.draw_expanding_section(

--- a/src/addons/send2ue/ui/dialog.py
+++ b/src/addons/send2ue/ui/dialog.py
@@ -63,7 +63,7 @@ class Send2UnrealDialog(bpy.types.Panel):
         properties = bpy.context.scene.send2ue
         self.draw_property(properties, layout, 'use_object_origin')
         self.draw_property(properties, layout, 'export_object_name_as_root')
-        self.draw_property(properties, layout, 'export_custom_root_name')
+        self.draw_property(properties, layout, 'export_custom_root_name', enabled=not properties.export_object_name_as_root)
 
         #  animation settings box
         self.draw_expanding_section(

--- a/tests/test_send2ue_cubes.py
+++ b/tests/test_send2ue_cubes.py
@@ -24,6 +24,10 @@ class TestSend2UeCubes(BaseSend2ueTestCase):
         pass
 
     @unittest.skip
+    def test_custom_root_bone_name(self):
+        pass
+
+    @unittest.skip
     def test_export_custom_property_fcurves_option(self):
         pass
 

--- a/tests/test_send2ue_mannequins.py
+++ b/tests/test_send2ue_mannequins.py
@@ -199,6 +199,19 @@ class TestSend2UeMannequins(BaseSend2ueTestCase):
                 'frames': [2, 6, 11]
             }})
 
+    def test_custom_root_bone_name(self):
+        """
+        Tests custom root bone name option.
+        """
+        self.run_custom_root_bone_name_option_tests({
+            'SK_Mannequin_Female': {
+                'rig': 'female_root',
+                'animations': ['third_person_walk_01', 'third_person_run_01'],
+                'bones': ['spine_02', 'calf_l', 'lowerarm_r'],
+                'frames': [2, 6, 11],
+                'custom_name': 'my_test_root_bone',
+            }})
+
     def test_export_custom_property_fcurves_option(self):
         """
         Tests export custom property fcurves option.


### PR DESCRIPTION
* Custom root bone name setting
* Custom root bone name tests

Useful when you have multiple armatures in a Blender project that you want to export when the skeleton in Unreal has a root bone. I could not use the "object name as root bone" as I cannot give two armatures the same name.

![image](https://github.com/user-attachments/assets/2a59763b-9e27-47d4-bc26-5d3d6c69c577)