### PR TITLE
UE2Rigify - Fixed incorrect indexing of template dropdown

### DIFF
--- a/src/addons/ue2rigify/__init__.py
+++ b/src/addons/ue2rigify/__init__.py
@@ -1,6 +1,5 @@
 # Copyright Epic Games, Inc. All Rights Reserved.
 
-import bpy
 import os
 import importlib
 from . import properties, operators, constants
@@ -13,7 +12,7 @@ bl_info = {
     "name": "UE to Rigify",
     "author": "Epic Games Inc (now a community fork)",
     "description": "Allows you to drive a given rig and its animations with a Rigify rig.",
-    "version": (1, 7, 2),
+    "version": (1, 7, 3),
     "blender": (3, 6, 0),
     "location": "3D View > Tools > UE to Rigify",
     "wiki_url": "https://poly-hammer.github.io/BlenderTools/ue2rigify",

--- a/src/addons/ue2rigify/blender_manifest.toml
+++ b/src/addons/ue2rigify/blender_manifest.toml
@@ -2,13 +2,13 @@ schema_version = "1.0.0"
 id = "ue2rigify"
 name = "UE to Rigify"
 tagline = "Allows you to drive a given rig and animations with a Rigify rig"
-version = "1.7.2"
+version = "1.7.3"
 type = "add-on"
 tags = ["Pipeline"]
 blender_version_min = "4.2.0"
 website = "https://poly-hammer.github.io/BlenderTools/ue2rigify"
 maintainer = "JoshQuake, jack-yao91"
-license = [ "SPDX:MIT" ]
+license = [ "SPDX:GPL-3.0-or-later" ]
 copyright = [
     "2020-2023 Epic Games, Inc."
 ]

--- a/src/addons/ue2rigify/core/templates.py
+++ b/src/addons/ue2rigify/core/templates.py
@@ -207,6 +207,11 @@ def get_rig_templates(self=None, context=None, index_offset=0):
         1 + index_offset
     ))
 
+    # remove from rig_template_directories
+    rig_template_directories.remove(Template.DEFAULT_MALE_TEMPLATE)
+    rig_template_directories.remove(Template.DEFAULT_FEMALE_TEMPLATE)
+
+    # enumerate remaining templates with an offset of 2
     for index, rig_template in enumerate(rig_template_directories, 2):
         if rig_template not in [Template.DEFAULT_MALE_TEMPLATE, Template.DEFAULT_FEMALE_TEMPLATE]:
             rig_templates.append((

--- a/src/addons/ue2rigify/release_notes.md
+++ b/src/addons/ue2rigify/release_notes.md
@@ -1,6 +1,7 @@
 ## Patch Changes
-* Extensions compliance - Avoid data.objects iteration
-  * [72](https://github.com/poly-hammer/BlenderTools/pull/72)
+* Fixed issue with creating multiple templates
+  * [91](https://github.com/poly-hammer/BlenderTools/pull/91)
+* Extensions compliance - License now GPL3.0
 
 ## Special Thanks
 * @JoshQuake


### PR DESCRIPTION
default templates are now removed from the rig_template_directories list after being added to the start of the dropdown