### PR TITLE
Send2UE - Fixed Affixes Error With Import Materials Disabled

### DIFF
--- a/src/addons/send2ue/resources/extensions/affixes.py
+++ b/src/addons/send2ue/resources/extensions/affixes.py
@@ -36,15 +36,15 @@ def add_affixes():
                 )
         else:
             append_affix(mesh_object, properties.extensions.affixes.static_mesh_name_affix)
+        if properties.import_materials_and_textures:
+            for slot in mesh_object.material_slots:
+                if slot.material:
+                    append_affix(slot.material, properties.extensions.affixes.material_name_affix)
 
-        for slot in mesh_object.material_slots:
-            if slot.material:
-                append_affix(slot.material, properties.extensions.affixes.material_name_affix)
-
-        texture_images = get_texture_images(mesh_object)
-        for image in texture_images:
-            save_image_filepath(image)
-        rename_all_textures(texture_images, append_affix, properties)
+            texture_images = get_texture_images(mesh_object)
+            for image in texture_images:
+                save_image_filepath(image)
+            rename_all_textures(texture_images, append_affix, properties)
 
     for rig_object in rig_objects:
         actions = utilities.get_actions(rig_object, properties.export_all_actions)
@@ -72,12 +72,12 @@ def remove_affixes():
             discard_affix(mesh_object, properties.extensions.affixes.skeletal_mesh_name_affix)
             if old_mesh_object_name == mesh_object.name:
                 break
+        if properties.import_materials_and_textures:
+            for slot in mesh_object.material_slots:
+                discard_affix(slot.material, properties.extensions.affixes.material_name_affix)
 
-        for slot in mesh_object.material_slots:
-            discard_affix(slot.material, properties.extensions.affixes.material_name_affix)
-
-        texture_images = get_texture_images(mesh_object)
-        rename_all_textures(texture_images, discard_affix, properties)
+            texture_images = get_texture_images(mesh_object)
+            rename_all_textures(texture_images, discard_affix, properties)
 
     for rig_object in rig_objects:
         actions = utilities.get_actions(rig_object, properties.export_all_actions)
@@ -352,7 +352,7 @@ class AffixesExtension(ExtensionBase):
         if self.auto_remove_asset_name_affixes:
             remove_affixes()
         
-        if self.auto_add_asset_name_affixes:
+        if properties.import_materials_and_textures and self.auto_add_asset_name_affixes:
             restore_texture_paths()
 
     def pre_validations(self, properties):

--- a/src/addons/send2ue/resources/extensions/affixes.py
+++ b/src/addons/send2ue/resources/extensions/affixes.py
@@ -36,15 +36,15 @@ def add_affixes():
                 )
         else:
             append_affix(mesh_object, properties.extensions.affixes.static_mesh_name_affix)
-        if properties.import_materials_and_textures:
-            for slot in mesh_object.material_slots:
-                if slot.material:
-                    append_affix(slot.material, properties.extensions.affixes.material_name_affix)
+        
+        for slot in mesh_object.material_slots:
+            if slot.material:
+                append_affix(slot.material, properties.extensions.affixes.material_name_affix)
 
-            texture_images = get_texture_images(mesh_object)
-            for image in texture_images:
-                save_image_filepath(image)
-            rename_all_textures(texture_images, append_affix, properties)
+        texture_images = get_texture_images(mesh_object)
+        for image in texture_images:
+            save_image_filepath(image)
+        rename_all_textures(texture_images, append_affix, properties)
 
     for rig_object in rig_objects:
         actions = utilities.get_actions(rig_object, properties.export_all_actions)
@@ -72,12 +72,12 @@ def remove_affixes():
             discard_affix(mesh_object, properties.extensions.affixes.skeletal_mesh_name_affix)
             if old_mesh_object_name == mesh_object.name:
                 break
-        if properties.import_materials_and_textures:
-            for slot in mesh_object.material_slots:
-                discard_affix(slot.material, properties.extensions.affixes.material_name_affix)
+        
+        for slot in mesh_object.material_slots:
+            discard_affix(slot.material, properties.extensions.affixes.material_name_affix)
 
-            texture_images = get_texture_images(mesh_object)
-            rename_all_textures(texture_images, discard_affix, properties)
+        texture_images = get_texture_images(mesh_object)
+        rename_all_textures(texture_images, discard_affix, properties)
 
     for rig_object in rig_objects:
         actions = utilities.get_actions(rig_object, properties.export_all_actions)


### PR DESCRIPTION
 - Fixed issue with affixes extension failing when properties.import_materials_and_textures is disabled.
 - Also prevents it from doing redundant file actions if disabled.