### PR TITLE
Add support for Python 3.13

### DIFF
--- a/src/addons/send2ue/dependencies/rpc/factory.py
+++ b/src/addons/send2ue/dependencies/rpc/factory.py
@@ -40,9 +40,10 @@ class RPCFactory:
         :rtype: str
         """
         # run the function code
-        exec('\n'.join(code))
+        local_env = {}
+        exec('\n'.join(code), None, local_env)
         # get the function from the locals
-        function_instance = locals().copy().get(function_name)
+        function_instance = local_env.get(function_name)
         # get the doc strings from the function
         return function_instance.__doc__
 

--- a/src/addons/send2ue/dependencies/rpc/factory.py
+++ b/src/addons/send2ue/dependencies/rpc/factory.py
@@ -156,8 +156,11 @@ class RPCFactory:
 
         # remove the doc string
         if doc_string:
-            code = '\n'.join(code).replace(doc_string, '')
-            code = [line for line in code.split('\n') if not all([char == '"' or char == "'" for char in line.strip()])]
+            # the doc string may not contain the exact same whitespace as the
+            # code, so we'll remove it with a regex
+            doc_string_lines = map(str.strip, doc_string.split('\n'))
+            re_doc_string = rf"[\"']{{3}}{"\s+".join(doc_string_lines)}[\"']{{3}}"
+            code = re.sub(re_doc_string, '', '\n'.join(code)).split('\n')
 
         return code
 


### PR DESCRIPTION
After installing v2.6.2 of the Send to Unreal addon, I found myself unable to push assets in Blender 4.3.2 running Python 3.13.1. I was able to get it working with the following fixes:

1. **Docstring Handling**:
- Updated the logic to strip docstrings using a regex to accommodate changes in Python 3.13, where the compiler now strips indentation from docstrings (see https://docs.python.org/3.13/whatsnew/3.13.html).
- The regex is a little dicey, but it works. I haven't tested older versions of Python, but it should work there as well. I'm open to other solutions should someone prefer to implement this in a manner that is more clean :)

2. **Explicit Locals Dictionary for `exec`**:
- Modified the code to pass an explicit locals dictionary to the `exec` function to ensure that the function instance is correctly captured in the locals (see https://docs.python.org/3/library/functions.html#exec).
