### PR TITLE
Send2UE - Added help label to combine assets

### DIFF
--- a/src/addons/send2ue/resources/extensions/combine_assets.py
+++ b/src/addons/send2ue/resources/extensions/combine_assets.py
@@ -65,6 +65,8 @@ class CombineAssetsExtension(ExtensionBase):
         """
         box = layout.box()
         dialog.draw_property(self, box, 'combine')
+        if self.combine == Options.CHILD_MESHES:
+            box.label(text="Meshes must be parented to an Empty to combine", icon="HELP")
 
     def pre_operation(self, properties):
         """


### PR DESCRIPTION
Added label that appears when Combine Assets is set to Child Meshes to indicate meshes must be parented to an empty.

Potential solution to #119 