### PR TITLE
Send2UE - Fixed UE2Rigify Error When No Source Rig Set

### DIFF
--- a/src/addons/send2ue/resources/extensions/ue2rigify.py
+++ b/src/addons/send2ue/resources/extensions/ue2rigify.py
@@ -62,7 +62,8 @@ class Ue2RigifyExtension(ExtensionBase):
         # sync the track values
         if self.use_ue2rigify and self.auto_sync_control_nla_to_source:
             bpy.context.scene.frame_set(0)
-            bpy.ops.ue2rigify.sync_rig_actions()
+            if bpy.context.scene.ue2rigify.source_rig:
+                bpy.ops.ue2rigify.sync_rig_actions()
 
     def post_operation(self, properties):
         """


### PR DESCRIPTION
Solves an error with the Use UE2Rigify extension when enabled but without a rig in the scene