### PR TITLE
Send2UE - Path Requires Leading Slash

### DIFF
--- a/src/addons/send2ue/core/formatting.py
+++ b/src/addons/send2ue/core/formatting.py
@@ -111,6 +111,12 @@ def auto_format_unreal_folder_path(name, properties):
             name,
             error_message
         )
+    elif not formatted_value.startswith('/'):
+        error_message = 'Path must have a leading forward slash. i.e. "/Game/"'
+        set_property_error_message(
+            name,
+            error_message
+        )
     elif not len(formatted_value.split('/')) >= 2:
         error_message = 'Please specify at least a root folder location.'
         set_property_error_message(


### PR DESCRIPTION
Added check for paths to start with a leading slash
![image](https://github.com/user-attachments/assets/1ef18fb0-0416-428b-823a-4016ea91de04)

Solves confusion like in #112 