### PR TITLE
Send2UE - Added Support for Meshes w/ Shapekeys

### DIFF
--- a/src/addons/send2ue/core/utilities.py
+++ b/src/addons/send2ue/core/utilities.py
@@ -187,7 +187,8 @@ def get_mesh_unreal_type(mesh_object):
     """
     has_parent_rig = mesh_object.parent and mesh_object.parent.type == BlenderTypes.SKELETON
     rig = get_armature_modifier_rig_object(mesh_object)
-    if has_parent_rig or rig:
+    has_shapekey = mesh_object.active_shape_key
+    if has_parent_rig or rig or has_shapekey:
         return UnrealTypes.SKELETAL_MESH
     return UnrealTypes.STATIC_MESH
 

--- a/src/addons/send2ue/resources/extensions/affixes.py
+++ b/src/addons/send2ue/resources/extensions/affixes.py
@@ -34,6 +34,11 @@ def add_affixes():
                     mesh_object,
                     properties.extensions.affixes.static_mesh_name_affix
                 )
+        elif mesh_object.active_shape_key:
+            append_affix(
+                mesh_object,
+                properties.extensions.affixes.skeletal_mesh_name_affix
+            )
         else:
             append_affix(mesh_object, properties.extensions.affixes.static_mesh_name_affix)
         


### PR DESCRIPTION
If static mesh has shapekeys, imports as SKM. Affix will also reflect being an SKM