### PR TITLE
Send2UE - Skip Legacy Check for Engine 5.4 and Lower

### DIFF
--- a/src/addons/send2ue/dependencies/unreal.py
+++ b/src/addons/send2ue/dependencies/unreal.py
@@ -1104,7 +1104,7 @@ class UnrealRemoteCalls:
     
     @staticmethod
     def is_using_legacy_fbx_importer():
-        if int(unreal.SystemLibrary.get_engine_version().split('-')[-1] >= 5.2):
+        if int(unreal.SystemLibrary.get_engine_version().split('-')[-1] >= 5.5):
             value = unreal.SystemLibrary.get_console_variable_string_value(r'Interchange.FeatureFlags.Import.FBX')
             return value.lower() in ['false', '0']
         else:

--- a/src/addons/send2ue/dependencies/unreal.py
+++ b/src/addons/send2ue/dependencies/unreal.py
@@ -1104,8 +1104,11 @@ class UnrealRemoteCalls:
     
     @staticmethod
     def is_using_legacy_fbx_importer():
-        value = unreal.SystemLibrary.get_console_variable_string_value(r'Interchange.FeatureFlags.Import.FBX')
-        return value.lower() in ['false', '0']
+        if int(unreal.SystemLibrary.get_engine_version().split('-')[-1] >= 5.2):
+            value = unreal.SystemLibrary.get_console_variable_string_value(r'Interchange.FeatureFlags.Import.FBX')
+            return value.lower() in ['false', '0']
+        else:
+            return True
 
     @staticmethod
     def has_socket(asset_path, socket_name):


### PR DESCRIPTION
Added skip for legacy check if unreal engine version is lower than 5.5