### PR TITLE
Send2UE - Skip Legacy Validation if Only Sending to Disk

### DIFF
--- a/src/addons/send2ue/__init__.py
+++ b/src/addons/send2ue/__init__.py
@@ -11,7 +11,7 @@ from .core import formatting, validations, settings, utilities, export, ingest, 
 bl_info = {
     "name": "Send to Unreal",
     "author": "Epic Games Inc (now a community fork)",
-    "version": (2, 6, 4),
+    "version": (2, 6, 5),
     "blender": (3, 6, 0),
     "location": "Header > Pipeline > Send to Unreal",
     "description": "Sends an asset to the first open Unreal Editor instance on your machine.",

--- a/src/addons/send2ue/core/validations.py
+++ b/src/addons/send2ue/core/validations.py
@@ -337,7 +337,7 @@ class ValidationManager:
                     )
                     return False
         
-        if self.properties.validate_project_settings:
+        if self.properties.validate_project_settings and self.properties.path_mode != PathModes.SEND_TO_DISK.value:
             if not UnrealRemoteCalls.is_using_legacy_fbx_importer():
                 utilities.report_error(
                     "The Legacy FBX Importer must be used instead of Scene Interchange. Please run this command in the "

--- a/src/addons/send2ue/release_notes.md
+++ b/src/addons/send2ue/release_notes.md
@@ -1,6 +1,6 @@
 ## Patch Changes
 * Fixed unreal connection error when sending to disk
-  * [142](https://github.com/poly-hammer/BlenderTools/pull/142)
+  * [148](https://github.com/poly-hammer/BlenderTools/pull/148)
 
 ## Special Thanks
 

--- a/src/addons/send2ue/release_notes.md
+++ b/src/addons/send2ue/release_notes.md
@@ -1,12 +1,8 @@
 ## Patch Changes
-* Fixed blender 4.4 operator compatibility issue
+* Fixed unreal connection error when sending to disk
   * [142](https://github.com/poly-hammer/BlenderTools/pull/142)
-* Skip legacy validation if not using UE5.5
-  * [144](https://github.com/poly-hammer/BlenderTools/pull/144)
 
 ## Special Thanks
-* @DanMcLaughlin
-* @mahreeoocedev01
 
 ## Tests Passing On
 * Blender `3.6`, `4.2` (installed from blender.org)


### PR DESCRIPTION
Skips legacy validation if Path mode is just Send to Disk

solves #147 