### PR TITLE
fix https://github.com/poly-hammer/BlenderTools/issues/135

### DIFF
--- a/src/addons/send2ue/core/io/__init__.py
+++ b/src/addons/send2ue/core/io/__init__.py
@@ -1,6 +1,6 @@
 from . import fbx_b3, fbx_b4
 
 __all__ = [
-    'fbx_b3'
+    'fbx_b3',
     'fbx_b4'
 ]


### PR DESCRIPTION
Comma were skipped, so as a consequence:

__all__ = ['fbx_b3' 'fbx_b4']

become:
__all__ = ['fbx_b3fbx_b4']
(python strings concatenating when follow each other

and both fbx_b3, fbx_b4 not available