### PR TITLE
Send2UE - Quick access push assets button

### DIFF
--- a/src/addons/send2ue/core/utilities.py
+++ b/src/addons/send2ue/core/utilities.py
@@ -1131,6 +1131,9 @@ def setup_project(*args):
     if not os.environ.get('SEND2UE_HIDE_PIPELINE_MENU'):
         header_menu.add_pipeline_menu()
 
+    # create the quick access button
+    if addon.preferences.quick_access_button:
+        header_menu.add_quick_access_button()
 
 def draw_error_message(self, context):
     """

--- a/src/addons/send2ue/properties.py
+++ b/src/addons/send2ue/properties.py
@@ -23,6 +23,11 @@ class Send2UeAddonProperties:
         default=True,
         description=f"This automatically creates the pre-defined collection (Export)"
     )
+    quick_access_button: bpy.props.BoolProperty(
+        name="Enable quick access push button",
+        default=True,
+        description="Adds a Push Assets button next to the Pipeline menu"
+    )
     # ------------- Remote Execution settings ------------------
     rpc_response_timeout: bpy.props.IntProperty(
         name="RPC Response Timeout",

--- a/src/addons/send2ue/properties.py
+++ b/src/addons/send2ue/properties.py
@@ -25,7 +25,7 @@ class Send2UeAddonProperties:
     )
     quick_access_button: bpy.props.BoolProperty(
         name="Enable quick access push button",
-        default=True,
+        default=False,
         description="Adds a Push Assets button next to the Pipeline menu"
     )
     # ------------- Remote Execution settings ------------------

--- a/src/addons/send2ue/properties.py
+++ b/src/addons/send2ue/properties.py
@@ -173,7 +173,7 @@ def get_scene_property_class():
                     PathModes.SEND_TO_PROJECT.value,
                     'Send to Project',
                     (
-                        'Sends the intermediate files to a temporary location on disk and then imports them into '
+                        'Sends the intermediate files to a temporary location on disk and then imports them into'
                         'the Unreal Project. This does not require any extra configuration, but might not be ideal if '
                         'your intermediate files need to be under source control.'
                     ),

--- a/src/addons/send2ue/properties.py
+++ b/src/addons/send2ue/properties.py
@@ -173,7 +173,7 @@ def get_scene_property_class():
                     PathModes.SEND_TO_PROJECT.value,
                     'Send to Project',
                     (
-                        'Sends the intermediate files to a temporary location on disk and then imports them into'
+                        'Sends the intermediate files to a temporary location on disk and then imports them into '
                         'the Unreal Project. This does not require any extra configuration, but might not be ideal if '
                         'your intermediate files need to be under source control.'
                     ),

--- a/src/addons/send2ue/ui/addon_preferences.py
+++ b/src/addons/send2ue/ui/addon_preferences.py
@@ -114,6 +114,8 @@ class SendToUnrealPreferences(Send2UeAddonProperties, bpy.types.AddonPreferences
         :param context: The context of this interface.
         """
         row = self.layout.row()
+        row.prop(self, 'quick_access_button')
+        row = self.layout.row()
         row.prop(self, 'automatically_create_collections')
         row = self.layout.row()
         row.label(text='RPC Response Timeout')

--- a/src/addons/send2ue/ui/header_menu.py
+++ b/src/addons/send2ue/ui/header_menu.py
@@ -55,6 +55,20 @@ class TOPBAR_MT_Pipeline(bpy.types.Menu):
     def draw(self, context):
         pass
 
+def quick_access(self, context):
+    self.layout.operator('wm.send2ue')
+
+def add_quick_access_button():
+    try:
+        bpy.types.TOPBAR_MT_editor_menus.remove(quick_access)
+    finally:
+        bpy.types.TOPBAR_MT_editor_menus.append(quick_access)
+
+def remove_quick_access_button():
+    try:
+        bpy.types.TOPBAR_MT_editor_menus.remove(quick_access)
+    finally:
+        pass
 
 def pipeline_menu(self, context):
     """


### PR DESCRIPTION
adds an addon preference to show a Push Assets button directly next to the Pipeline menu for quick access. Its usefulness is arguable as it only removes 2 clicks from the usual way to push assets. Jack I will let you decide if it's worth adding lol

![image](https://github.com/user-attachments/assets/44e28d19-2d84-4a4d-ba55-45e52f4ac0af)
