### PR TITLE
Send2UE - Place Mesh Instances In Level

### DIFF
--- a/src/addons/send2ue/release_notes.md
+++ b/src/addons/send2ue/release_notes.md
@@ -1,6 +1,6 @@
 ## Patch Changes
-* Fixed addon preferences setter/getters to be compatible with Blender 5.0
-  * [174](https://github.com/poly-hammer/BlenderTools/issues/174)
+* Fixed mesh instances being placed in level
+  * [171](https://github.com/poly-hammer/BlenderTools/issues/171)
 
 ## Special Thanks
 @kelitraynaud

--- a/src/addons/send2ue/resources/extensions/instance_assets.py
+++ b/src/addons/send2ue/resources/extensions/instance_assets.py
@@ -2,6 +2,7 @@
 
 import bpy
 import os
+import re
 from send2ue.constants import UnrealTypes
 from send2ue.core.extension import ExtensionBase
 from send2ue.core.utilities import (
@@ -169,8 +170,14 @@ class InstanceAssetsExtension(ExtensionBase):
                             break
 
             if unique_name:
+                asset_path = ''
+                if not asset_data['skip']:
+                    asset_path = asset_data['asset_path']
+                else:
+                    asset_path = re.sub(r'_\d+$', "",asset_data['asset_path'])
+                    
                 make_remote(UnrealCalls).instance_asset(
-                    asset_data['asset_path'],
+                    asset_path,
                     convert_blender_to_unreal_location(location),
                     convert_blender_rotation_to_unreal_rotation(rotation),
                     scale,


### PR DESCRIPTION
When placing meshes in level, if the asset is marked as skip it's most likely an instance so it now looks to remove a trailing _### in the asset path to get the parent object.

Currently does not account for instances that are renamed to be different from the original object.

Solves #171 